### PR TITLE
[#3] update dependency-versions to match CRAN

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -15,7 +15,7 @@ source:
   sha256: 2b186dae1b19018681b979e9444bf16559c42740d8382676fbaf3b0f8a44337e
 
 build:
-  number: 0
+  number: 1
   # r-igraph is not available for Windows
   skip: true  # [win]
   rpaths:
@@ -25,46 +25,48 @@ build:
 requirements:
   build:
     - r-base
-    - r-dplyr >=0.5.0
+    - r-dplyr >=0.7.4
     - r-downloader >=0.4
+    - r-glue >=1.2.0
     - r-htmltools >=0.3.6
     - r-htmlwidgets >=1.0
     - r-igraph >=1.1.2
     - r-influencer >=0.1.0
     - r-magrittr >=1.5
-    - r-purrr >=0.2.3
+    - r-purrr >=0.2.4
     - r-rcolorbrewer >=1.1_2
     - r-readr >=1.1.1
-    - r-rlang >=0.1.1
-    - r-rstudioapi >=0.6
+    - r-rlang >=0.2.0
+    - r-rstudioapi >=0.7
     - r-rgexf >=0.15.3
     - r-scales >=0.5.0
-    - r-stringr >=1.2.0
-    - r-tibble >=1.3.3
-    - r-tidyr >=0.6.3
+    - r-stringr >=1.3.0
+    - r-tibble >=1.4.2
+    - r-tidyr >=0.8.0
     - r-viridis >=0.5.0
-    - r-visnetwork >=2.0.1
+    - r-visnetwork >=2.0.3
   run:
     - r-base
-    - r-dplyr >=0.5.0
+    - r-dplyr >=0.7.4
     - r-downloader >=0.4
+    - r-glue >=1.2.0
     - r-htmltools >=0.3.6
     - r-htmlwidgets >=1.0
     - r-igraph >=1.1.2
     - r-influencer >=0.1.0
     - r-magrittr >=1.5
-    - r-purrr >=0.2.3
+    - r-purrr >=0.2.4
     - r-rcolorbrewer >=1.1_2
     - r-readr >=1.1.1
-    - r-rlang >=0.1.1
-    - r-rstudioapi >=0.6
+    - r-rlang >=0.2.0
+    - r-rstudioapi >=0.7
     - r-rgexf >=0.15.3
     - r-scales >=0.5.0
-    - r-stringr >=1.2.0
-    - r-tibble >=1.3.3
-    - r-tidyr >=0.6.3
+    - r-stringr >=1.3.0
+    - r-tibble >=1.4.2
+    - r-tidyr >=0.8.0
     - r-viridis >=0.5.0
-    - r-visnetwork >=2.0.1
+    - r-visnetwork >=2.0.3
 
 test:
   commands:


### PR DESCRIPTION
A number of the package versions in the meta.yaml for r-diagrammer preceded
those in the 'imports' section of the CRAN-DiagrammeR page; this despite
the current version of DiagrammeR on CRAN being the same as the version on
conda-forge (v-1.0.0).

The dependency versions for r-diagrammer=1.0.0 were updated to match those
at CRAN for DiagrammeR 1.0.0.

build/number was increased by 1 since the r-diagrammer package version was
not changed.